### PR TITLE
Remove unnecessary comments as per review feedback

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -43,11 +43,7 @@ pub struct Config {
   pub backup_hours: u64,
   pub download_token_lifetime: i64,
   pub base_url: String,
-  /// Minimum free disk space in bytes before triggering yanked builds GC.
-  /// Default: 500MB (enough for ~2 releases at ~230MB each)
   pub gc_min_free_space: u64,
-  /// Interval in seconds for checking disk space and triggering GC.
-  /// Default: 60 seconds
   pub gc_check_interval_secs: u64,
 }
 

--- a/src/sv/build.rs
+++ b/src/sv/build.rs
@@ -156,13 +156,11 @@ impl<'a> Build<'a> {
       .await?
       .ok_or(Error::BuildNotFound)?;
 
-    // Remove file from disk if it exists
     let path = Path::new(&build.file_path);
     if path.exists() {
       fs::remove_file(path).await.ok();
     }
 
-    // Delete from database
     build::Entity::delete_by_id(build.id).exec(self.db).await?;
 
     Ok(build)


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #16 by removing unnecessary comments:
- Removed doc comments for `gc_min_free_space` and `gc_check_interval_secs` in `src/state.rs`
- Removed inline comments in `src/sv/build.rs` delete method

## Changes

As requested in [review comments](https://github.com/uselessgoddess/license/pull/16#pullrequestreview-3624355847):
- `src/state.rs`: Removed doc comments for GC config fields
- `src/sv/build.rs`: Removed `// Remove file from disk if it exists` and `// Delete from database` comments

## Test Plan

- [x] `cargo check --all-targets` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test --all-targets` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)